### PR TITLE
Update github-script to v6

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Publish release
       id: publish
-      uses: actions/github-script@v4
+      uses: actions/github-script@v6
       with:
         script: |
           const fs = require('fs');
@@ -36,7 +36,7 @@ runs:
 
           const source = fs.readFileSync('${{ inputs.filename }}');
 
-          const release = await github.repos.createRelease({
+          const release = await github.rest.repos.createRelease({
               owner: context.repo.owner, repo: context.repo.repo,
               tag_name: version, name: version, body: release_body, draft: true
               });
@@ -44,7 +44,7 @@ runs:
           /* We get a lot of connection reset errors... */
           for (let retry = 0; retry < 5; retry++) {
               try {
-                  const upload = await github.repos.uploadReleaseAsset({
+                  const upload = await github.rest.repos.uploadReleaseAsset({
                       owner: context.repo.owner, repo: context.repo.repo, release_id: release.data.id,
                       name: '${{ inputs.filename }}', headers: {'Content-Type': 'application/x-xz'}, data: source});
                   break;
@@ -56,7 +56,7 @@ runs:
               }
           }
 
-          const update = await github.repos.updateRelease({
+          const update = await github.rest.repos.updateRelease({
             owner: context.repo.owner, repo: context.repo.repo, release_id: release.data.id,
             draft: false});
 


### PR DESCRIPTION
Our publish release workflow shows warnings about using the `set-output` command which is deprecated. The workflow uses it indirectly via actions/github-script, in v5 the rest methods have been moved to github.rest and in v6 there are no breaking changes except it now can run on Node 16.

See https://github.com/actions/github-script#breaking-changes for details.