### PR TITLE
Bump to github-script@v7

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ runs:
 
     - name: Publish release
       id: publish
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const fs = require('fs');


### PR DESCRIPTION
This gets rid of the obsolete node.js 16.

---

This gets rid of the node.js 16 warning, seen in e.g. our [most recent c-podman release](https://github.com/cockpit-project/cockpit-podman/actions/runs/7969027553). I spotted it today on a [python-dbusmock release](https://github.com/martinpitt/python-dbusmock/actions/runs/8016415747).